### PR TITLE
Default getRawTransaction to provide verbose response.

### DIFF
--- a/dist/neo.blockchain.node.js
+++ b/dist/neo.blockchain.node.js
@@ -290,7 +290,7 @@ module.exports = function(network) {
       return new Promise(function(resolve, reject){
         node.call({
           method: "getrawtransaction",
-          params: [txid],
+          params: [txid,1],
           id: 0
         })
         .then(function (data) {


### PR DESCRIPTION
Current `getRawTransaction` doesn't provide useful response from RPC.

Example response without verbose mode (current state):

```
{"jsonrpc":"2.0","id":1,"result":"00005a396f5e00000000"}
```

Example response with verbose mode:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "txid": "0x40c2a24c32271210b1aa1e89c938494312d4b1dd0315ee8dad2a52b4e66d8042",
        "size": 10,
        "type": "MinerTransaction",
        "version": 0,
        "attributes": [
        ],
        "vin": [
        ],
        "vout": [
        ],
        "sys_fee": "0",
        "net_fee": "0",
        "scripts": [
        ],
        "nonce": 1584347482,
        "blockhash": "0xd60d44b5bcbb84d732fcfc31397b81c4e21c7300b9627f890b0f75c863f0c122",
        "confirmations": 511342,
        "blocktime": 1496454840
    }
}
```
