### PR TITLE
Bugfix getTXOut method on lack of mandatory index argument.

### DIFF
--- a/dist/neo.blockchain.node.js
+++ b/dist/neo.blockchain.node.js
@@ -307,12 +307,12 @@ module.exports = function(network) {
     * @param {string} txid The requested transaction ID.
     * @returns {Promise.<Object>} An object containing the transaction response.
     */
-    this.getTXOut = function(txid){
+    this.getTXOut = function(txid, index){
 
       return new Promise(function(resolve, reject){
         node.call({
           method: "gettxout",
-          params: [txid],
+          params: [txid, index],
           id: 0
         })
         .then(function (data) {


### PR DESCRIPTION
A second input argument is required for `gettxout` RPC API in order to obtain a valid response.
