### PR TITLE
Add linting into package builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A package for running a full or light node on the neo blockchain.",
   "main": "dist/neo.blockchain.neo.js",
   "scripts": {
-    "standard": "node_modules/standard/bin/cmd.js test/**/*.js || exit 0",
+    "lint": "node_modules/standard/bin/cmd.js **/*.js || exit 0",
     "integration": "node_modules/mocha/bin/mocha -b test/integration/*.js",
     "test": "node_modules/mocha/bin/mocha -b test/unit/*.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A package for running a full or light node on the neo blockchain.",
   "main": "dist/neo.blockchain.neo.js",
   "scripts": {
+    "standard": "node_modules/standard/bin/cmd.js test/**/*.js || exit 0",
     "integration": "node_modules/mocha/bin/mocha -b test/integration/*.js",
     "test": "node_modules/mocha/bin/mocha -b test/unit/*.js"
   },
@@ -31,6 +32,7 @@
   "devDependencies": {
     "axios-mock-adapter": "^1.9.0",
     "chai": "^4.1.2",
-    "mocha": "^3.5.3"
+    "mocha": "^3.5.3",
+    "standard": "^10.0.3"
   }
 }


### PR DESCRIPTION
Using `standard` as linting tool as well as uniform JS coding style.

Sample command line usage:

`npm run lint`

or direct access to local copy of standard CLI:

`node_modules/standard/bin/cmd.js **/*.js`
