### PR TITLE
Update getBlockSystemFee() to return fee in integer oppose to string.

### DIFF
--- a/dist/neo.blockchain.node.js
+++ b/dist/neo.blockchain.node.js
@@ -305,18 +305,18 @@ module.exports = function(network) {
     * @param {number} index The index of the block hash being requested.
     * @example
     * node.getBlockSystemFee(100000)
-    * return '905'
-    * @returns {Promise.<string>} The system fee.
+    * return 905
+    * @returns {Promise.<number>} The system fee.
     */
-    this.getBlockSystemFee = function(height){
+    this.getBlockSystemFee = function(index){
       return new Promise(function(resolve, reject){
         node.call({
           method: "getblocksysfee",
-          params: [height],
+          params: [index],
           id: 0
         })
         .then(function(data){
-          resolve(data.result);
+          resolve(parseInt(data.result));
         })
         .catch(function(err){
           reject(err);

--- a/test/integration/block.js
+++ b/test/integration/block.js
@@ -91,11 +91,12 @@ describe(`${describeBadge} getBlockHash()`, () => {
 })
 
 describe(`${describeBadge} getBlockSystemFee()`, () => {
-  it('should have string as its response data type.', (done) => {
+  it('should be a whole number as its response.', (done) => {
     neoNode.getBlockSystemFee(Profiles.Blocks.Block_100000.Number)
       .then((res) => {
         const fee = res
-        expect(fee).to.be.a('string')
+        expect(fee).to.be.a('number')
+        expect(fee % 1).to.be.equal(0)
         done()
       })
       .catch((err) => {

--- a/test/unit/block.js
+++ b/test/unit/block.js
@@ -91,11 +91,12 @@ describe('Unit test getBlockHash()', () => {
 })
 
 describe('Unit test getBlockSystemFee()', () => {
-  it('should have string as its response data type.', (done) => {
+  it('should be a whole number as its response.', (done) => {
     neoNode.getBlockSystemFee(Profiles.Blocks.Block_100000.Number)
       .then((res) => {
         const fee = res
-        expect(fee).to.be.a('string')
+        expect(fee).to.be.a('number')
+        expect(fee % 1).to.be.equal(0)
         done()
       })
       .catch((err) => {


### PR DESCRIPTION
To address concern in issue #16 , updated the return type of `getBlockSystemFee` from string to number for better usability.

Return data of `getblocksysfee` RPC is increment of whole number, stored in string type.
