### PR TITLE
Add utility building scripts into package builder

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/neo.blockchain.neo.js",
   "scripts": {
     "integration": "node_modules/mocha/bin/mocha -b test/integration/*.js",
-    "test": "node_modules/mocha/bin/mocha -b test/unit/*.js"
+    "test": "node_modules/mocha/bin/mocha -b test/unit/*.js",
+    "rebuild": "rm -rf node_modules && rm package-lock.json && npm install",
+    "prepublish": "echo \"Not Implemented: unit test, JS lint and documentations to be performed here.\" && exit 0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "integration": "./node_modules/.bin/mocha -b ./test/integration/*.js",
     "test": "./node_modules/.bin/mocha -b ./test/unit/*.js",
     "coverage": "./node_modules/.bin/nyc npm test",
-    "rebuild": "rm -rf node_modules && rm package-lock.json && npm install",
+    "rebuild": "rm -rf ./node_modules && rm -f ./package-lock.json && npm install",
     "prepublish": "echo \"Not Implemented: unit test, JS lint and documentations to be performed here.\" && exit 0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "A package for running a full or light node on the neo blockchain.",
   "main": "dist/neo.blockchain.neo.js",
   "scripts": {
-    "lint": "node_modules/standard/bin/cmd.js **/*.js || exit 0",
-    "integration": "node_modules/mocha/bin/mocha -b test/integration/*.js",
-    "test": "node_modules/mocha/bin/mocha -b test/unit/*.js",
-    "coverage": "node_modules/nyc/bin/nyc.js npm test",
+    "lint": "./node_modules/.bin/standard ./**/*.js || exit 0",
+    "integration": "./node_modules/.bin/mocha -b ./test/integration/*.js",
+    "test": "./node_modules/.bin/mocha -b ./test/unit/*.js",
+    "coverage": "./node_modules/.bin/nyc npm test",
     "rebuild": "rm -rf node_modules && rm package-lock.json && npm install",
     "prepublish": "echo \"Not Implemented: unit test, JS lint and documentations to be performed here.\" && exit 0"
   },


### PR DESCRIPTION
Introduce `npm run rebuild` for simpler way to reinstantiate the project.

`npm run republish` is currently a placeholder that will be an aggregator of multiple scripts.
