### PR TITLE
Change on MongoDB storage response strategy

### DIFF
--- a/dist/node/storage/mongodb.js
+++ b/dist/node/storage/mongodb.js
@@ -82,9 +82,6 @@ class MongodbStorage {
           if (err) {
             reject(err)
           }
-          if (!res) {
-            reject(new Error('transaction not found'))
-          }
           resolve(res)
         })
     })
@@ -106,27 +103,6 @@ class MongodbStorage {
         .exec((err, res) => {
           if (err) {
             reject(err)
-          }
-
-          if (!res) {
-            reject(new Error('Block not found'))
-          }
-
-          resolve(res)
-        })
-    })
-  }
-
-  getBlockList() {
-    return new Promise((resolve, reject) => {
-      this.blockModel.find({}, 'index')
-        .sort('index')
-        .exec((err, res) => {
-          if (err) {
-            reject(err)
-          }
-          if (!res) {
-            reject(new Error('Block not found.'))
           }
           resolve(res)
         })
@@ -152,13 +128,11 @@ class MongodbStorage {
 
   getAssetList() {
     return new Promise((resolve, reject) => {
-      this.addressModel.find({ type: 'a' }, 'asset')
+      // this.addressModel.find({ type: 'a' }, 'asset')
+      this.addressModel.find({ type: 'a' })
         .exec((err, res) => {
           if (err) {
             reject(err)
-          }
-          if (!res) {
-            reject(new Error('assets not found'))
           }
           resolve(res)
         })
@@ -181,9 +155,6 @@ class MongodbStorage {
         .exec((err, res) => {
           if (err) {
             reject(err)
-          }
-          if (!res) {
-            reject(new Error('assets not found'))
           }
           resolve(res)
         })


### PR DESCRIPTION
This is a precursor to asset support feature.

## Description
Normalize response strategy of some of the methods in `/node/storage/mongodb.js` as some of response decisions are too specific.

* Remove strategy on "reject a promise when query result is falsy".
* Update `getAssetList()` to response with whole document instead of specific property only.
* Remove `getBlockList()` as it never been used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

