### PR TITLE
Disable default NEO Seed1 Testnet

### DIFF
--- a/dist/profiles.js
+++ b/dist/profiles.js
@@ -16,7 +16,7 @@ const profiles = {
     },
     testnet: {
       endpoints: [
-        { domain: 'http://seed1.neo.org', port: 20332 },
+        // { domain: 'http://seed1.neo.org', port: 20332 },
         { domain: 'http://seed2.neo.org', port: 20332 },
         { domain: 'http://seed3.neo.org', port: 20332 },
         { domain: 'http://seed4.neo.org', port: 20332 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The default NEO Seed1 Testnet `http://seed1.neo.org:20332` seems to be frequently unavailable. Remove this from the default list for the time being.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
