### PR TITLE
Incorrect balance checking

### DIFF
--- a/dist/node/storage/mongodb.js
+++ b/dist/node/storage/mongodb.js
@@ -281,11 +281,20 @@ class MongodbStorage extends EventEmitter {
     this.logger.debug('getAssetListByAddress triggered. address:', address, 'assetHash:', assetHash, 'startBlock:', startBlock)
     return new Promise((resolve, reject) => {
       this.transactionModel.find({
-        'vout.address': address,
-        $or: [
-          {type: 'ContractTransaction'},
-          {type: 'InvocationTransaction'},
-          {type: 'ClaimTransaction'}
+        $and: [
+          {
+            $or: [
+              {'vout.address': address},
+              {'vin.address': address}
+            ],
+          },
+          {
+            $or: [
+              {type: 'ContractTransaction'},
+              {type: 'InvocationTransaction'},
+              {type: 'ClaimTransaction'}
+            ],
+          }
         ],
         'vout.asset': assetHash,
         blockIndex: { $gte: startBlock }


### PR DESCRIPTION
The `getAssetBalance()` function returns incorrect values.

## Description
The problem seems to be that `getAssetListByAddress()` only includes transactions where the address is in the `vout` part of the tx (where the address **receives** funds).
In order to have the current balance, we need to include the transactions where the funds are **leaving** the address (where the address is in the `vin` part of the tx).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
