### PR TITLE
Fixes CityOfZion/neo-js/#163

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "private": false,
   "description": "A package for running a node on the neo blockchain.",
-  "main": "dist/node.js",
+  "main": "dist/neo.js",
   "scripts": {
     "lint": "./node_modules/.bin/eslint ./{dist,examples,test} --ext .js",
     "test": "./node_modules/.bin/mocha -b ./test/unit/**/*",


### PR DESCRIPTION
## Description
The file referenced as the primary entry point in `package.json` `dist/node.js` was missing. This reference is now changed to the existing file `dist/neo.js`

## Motivation and Context
Without a primary entry point it's not possible to include/require the package.

## How Has This Been Tested?
Small change, tested on my workstation. Presuming that this won't break anything else.

## Types of changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.